### PR TITLE
Fix for NPE in Twilight Forest caused by missing call to WorldServer#init()

### DIFF
--- a/src/main/java/lumien/simpledimensions/server/WorldCustom.java
+++ b/src/main/java/lumien/simpledimensions/server/WorldCustom.java
@@ -64,6 +64,7 @@ public class WorldCustom extends WorldServer
 
     public World init()
     {
+        super.init();
         this.mapStorage = this.delegate.getMapStorage();
         this.worldScoreboard = this.delegate.getScoreboard();
         this.lootTable = this.delegate.getLootTableManager();


### PR DESCRIPTION
As described by @Tamaized at https://github.com/TeamTwilight/twilightforest/issues/334#issuecomment-344767981 there is an issue with the advancementManager variable not being populated due to a missing call to WorldServer#init.
This commit adds this call and therefore fixes these issues;

https://github.com/TeamTwilight/twilightforest/issues/334
https://github.com/lumien231/Simple-Dimensions/issues/12

For those interested, here is a link to a jar with this fix implemented: [SimpleDimensions-MC1.12-1.3.1-patched.jar](https://cdn.ikkerens.com/download/SimpleDimensions-MC1.12-1.3.1-patched.jar)